### PR TITLE
Handle case when car doesn't touch the ball

### DIFF
--- a/rlgym/utils/reward_functions/common_rewards.py
+++ b/rlgym/utils/reward_functions/common_rewards.py
@@ -11,8 +11,7 @@ class TouchBallReward(RewardFunction):
         pass
 
     def get_reward(self, player: PlayerData, state: GameState, previous_action: np.ndarray, optional_data=None):
-        if player.ball_touched:
-            return 1
+        return 1 if player.ball_touched else 0
 
     def get_final_reward(self, player: PlayerData, state: GameState, previous_action: np.ndarray, optional_data=None):
         return 0


### PR DESCRIPTION
Previously, calling TouchBallReward will result in errors (TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'). This is due to an unhandeled case when the car doesn't touch the ball.
This fix resolves this bug by return 0 if not touch