### PR TITLE
Modified discrete_act.py in order to support n_bins > 3

### DIFF
--- a/rlgym/utils/action_parsers/discrete_act.py
+++ b/rlgym/utils/action_parsers/discrete_act.py
@@ -18,10 +18,7 @@ class DiscreteAction(ActionParser):
         return gym.spaces.MultiDiscrete([self._n_bins] * 5 + [2] * 3)
 
     def parse_actions(self, actions: np.ndarray, state: GameState) -> np.ndarray:
-        actions = actions.reshape((-1, 8))
-
-        # add a cast to float64 to allow bins > 3 to work
-        actions = actions.astype(dtype=np.float64, casting='safe', copy=True)
+        actions = actions.reshape((-1, 8)).astype(dtype=np.float32)
 
         # map all binned actions from {0, 1, 2 .. n_bins - 1} to {-1 .. 1}.
         actions[..., :5] = actions[..., :5] / (self._n_bins // 2) - 1

--- a/rlgym/utils/action_parsers/discrete_act.py
+++ b/rlgym/utils/action_parsers/discrete_act.py
@@ -20,7 +20,10 @@ class DiscreteAction(ActionParser):
     def parse_actions(self, actions: np.ndarray, state: GameState) -> np.ndarray:
         actions = actions.reshape((-1, 8))
 
-        # map all ternary actions from {0, 1, 2} to {-1, 0, 1}.
+        # add a cast to float64 to allow bins > 3 to work
+        actions = actions.astype(dtype=np.float64, casting='safe', copy=True)
+
+        # map all binned actions from {0, 1, 2 .. n_bins - 1} to {-1 .. 1}.
         actions[..., :5] = actions[..., :5] / (self._n_bins // 2) - 1
 
         return actions


### PR DESCRIPTION
pedal-force from the discord. Changed and tested discrete_act.py changes. Shouldn't change the existing behavior of 3 bins. Some example prints are below from 3 bins.
orig type of actions is int64 and orig actions are:
[[1 0 1 2 0 1 0 0]
 [0 1 2 0 1 0 1 0]]
new actions
[[ 0. -1.  0.  1. -1.  1.  0.  0.]
 [-1.  0.  1. -1.  0.  0.  1.  0.]]