### PR TITLE
Boost pickup event reward

### DIFF
--- a/rlgym/utils/reward_functions/common_rewards/misc_rewards.py
+++ b/rlgym/utils/reward_functions/common_rewards/misc_rewards.py
@@ -8,7 +8,7 @@ from rlgym.utils.reward_functions import RewardFunction
 
 
 class EventReward(RewardFunction):
-    def __init__(self, goal=0., team_goal=0., concede=-0., touch=0., shot=0., save=0., demo=0.):
+    def __init__(self, goal=0., team_goal=0., concede=-0., touch=0., shot=0., save=0., demo=0., boost_pickup=0.):
         """
         :param goal: reward for goal scored by player.
         :param team_goal: reward for goal scored by player's team.
@@ -17,9 +17,10 @@ class EventReward(RewardFunction):
         :param shot: reward for shooting the ball (as detected by Rocket League).
         :param save: reward for saving the ball (as detected by Rocket League).
         :param demo: reward for demolishing a player.
+        :param boost_pickup: reward for picking up boost. big pad = +1.0 boost, small pad = +0.12 boost.
         """
         super().__init__()
-        self.weights = np.array([goal, team_goal, concede, touch, shot, save, demo])
+        self.weights = np.array([goal, team_goal, concede, touch, shot, save, demo, boost_pickup])
 
         # Need to keep track of last registered value to detect changes
         self.last_registered_values = {}
@@ -32,7 +33,7 @@ class EventReward(RewardFunction):
             team, opponent = state.orange_score, state.blue_score
 
         return np.array([player.match_goals, team, opponent, player.ball_touched, player.match_shots,
-                         player.match_saves, player.match_demolishes])
+                         player.match_saves, player.match_demolishes, player.boost_amount])
 
     def reset(self, initial_state: GameState, optional_data=None):
         # Update every reset since rocket league may crash and be restarted with clean values


### PR DESCRIPTION
This PR adds a boost pickup event reward. The weight is multiplied by the amount of boost picked up. If the player starts with empty boost, the big boost pads will increase boost by 1.0 and the small boost pads will increase boost by 0.12.