### PR TITLE
Add maximum python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'pywinauto==0.6.8',
         'psutil>=5.8',
     ],
-    python_requires='>=3.7',
+    python_requires='>=3.7, <=3.9.*',
     cmdclass={'install': CustomInstall},
     license='Apache 2.0',
     license_file='LICENSE',


### PR DESCRIPTION
Should give a clearer error message when trying to use 3.10+