### PR TITLE
allow explicit epic exe path to allow old and new exe to exist.

### DIFF
--- a/rlgym/gamelaunch/epic_launch.py
+++ b/rlgym/gamelaunch/epic_launch.py
@@ -10,10 +10,11 @@ import re
 
 # Copied from https://github.com/RLBot/RLBot/blob/master/src/main/python/rlbot/gamelaunch/epic_launch.py
 
-def launch_with_epic_simple(ideal_args: List[str]) -> Optional[subprocess.Popen]:
+def launch_with_epic_simple(ideal_args: List[str], epic_rl_exe_path=None) -> Optional[subprocess.Popen]:
     try:
         # Try launch via Epic Games
-        epic_rl_exe_path = locate_epic_games_launcher_rocket_league_binary()
+        if epic_rl_exe_path is None:
+            epic_rl_exe_path = locate_epic_games_launcher_rocket_league_binary()
         if epic_rl_exe_path is not None:
             exe_and_args = [str(epic_rl_exe_path)] + ideal_args + ['-EpicPortal']
             # print(f'Launching Rocket League with: {exe_and_args}')

--- a/rlgym/gamelaunch/launch.py
+++ b/rlgym/gamelaunch/launch.py
@@ -35,7 +35,8 @@ def run_injector():
     subprocess.Popen([injector_command])
 
 
-def launch_rocket_league(pipe_id, launch_preference: str = LaunchPreference.EPIC) -> Optional[subprocess.Popen]:
+def launch_rocket_league(pipe_id, launch_preference: str = LaunchPreference.EPIC, epic_rl_exe_path=None)\
+        -> Optional[subprocess.Popen]:
     """
     Launches Rocket League but does not connect to it.
     """
@@ -56,7 +57,7 @@ def launch_rocket_league(pipe_id, launch_preference: str = LaunchPreference.EPIC
             else:
                 print("Epic login trick seems to have failed, falling back to simple Epic launch.")
         # Fall back to simple if the tricks failed or we opted out of tricks.
-        game_process = launch_with_epic_simple(ideal_args)
+        game_process = launch_with_epic_simple(ideal_args, epic_rl_exe_path)
         if game_process:
             print('Launched Epic version')
             return game_process

--- a/rlgym/gym.py
+++ b/rlgym/gym.py
@@ -15,7 +15,9 @@ from rlgym.gamelaunch.minimize import toggle_rl_process
 
 class Gym(Env):
     def __init__(self, match, pipe_id=0, launch_preference=LaunchPreference.EPIC, use_injector=False,
-                 force_paging=False, raise_on_crash=False, auto_minimize=False):
+                 force_paging=False, raise_on_crash=False, auto_minimize=False,
+                 epic_rl_exe_path=None
+                 ):
         super().__init__()
 
         self._match = match
@@ -25,6 +27,7 @@ class Gym(Env):
         self._launch_preference = launch_preference
         self._use_injector = use_injector
         self._force_paging = force_paging
+        self._epic_rl_exe_path = epic_rl_exe_path
 
         self._raise_on_crash = raise_on_crash
 
@@ -49,7 +52,7 @@ class Gym(Env):
     def _open_game(self):
         print("Launching Rocket League, make sure bakkesmod is running.")
         # Game process is only set if epic version is used or launched with path_to_rl
-        self._game_process = launch_rocket_league(self._local_pipe_name, self._launch_preference)
+        self._game_process = launch_rocket_league(self._local_pipe_name, self._launch_preference, self._epic_rl_exe_path)
 
         if self._use_injector:
             sleep(3)


### PR DESCRIPTION
This allows someone to easily have two version of Rocket League on their machine, and point rlgym explicitly to the old compatible version, so that Epic can be updated properly to allow online play and rlbot convenience without breaking rlgym training. The changes are non-breaking and have been tested both with an empty parameter and a new explicit parameter to link to the old Rocket League, and appear to work properly.