### PR TITLE
Fix Epic launch without launcher

### DIFF
--- a/rlgym/gamelaunch/epic_launch.py
+++ b/rlgym/gamelaunch/epic_launch.py
@@ -15,7 +15,7 @@ def launch_with_epic_simple(ideal_args: List[str]) -> Optional[subprocess.Popen]
         # Try launch via Epic Games
         epic_rl_exe_path = locate_epic_games_launcher_rocket_league_binary()
         if epic_rl_exe_path is not None:
-            exe_and_args = [str(epic_rl_exe_path)] + ideal_args + ['-EpicPortal']
+            exe_and_args = [str(epic_rl_exe_path)] + ideal_args + ['-EpicPortal', '-AUTH_PASSWORD=0']
             # print(f'Launching Rocket League with: {exe_and_args}')
             try:
                 return subprocess.Popen(exe_and_args)


### PR DESCRIPTION
Got alerted about RLGym breaking and some concerns/conspiracy theories about a possible anticheat blocking it so I did some investigating. Looks like running the game with just -EpicPortal breaks the auth, adding -AUTH_PASSWORD=0 to the launch options fixes it. 

This should work as launching one instance works fine (Epic launcher doesn't open). However I couldn't test it with multi instances since I'm running into too many python errors/installation issues with the SB3 multi instance example on my end I cba to fix.