### PR TITLE
Missing option to install full simulation engine (including Rlviser)

### DIFF
--- a/setup_rlgym.py
+++ b/setup_rlgym.py
@@ -25,6 +25,7 @@ requires = [
 extras = {
     'rl': ['rlgym-rocket-league[all] =={}'.format(rl_version)],
     'rl-sim': ['rlgym-rocket-league[sim] =={}'.format(rl_version)],
+    'rl-fullsim': ['rlgym-rocket-league[rlviser] =={}'.format(rl_version)],
     'rl-game': ['rlgym-rocket-league[game] =={}'.format(rl_version)],
 }
 

--- a/setup_rlgym.py
+++ b/setup_rlgym.py
@@ -25,7 +25,7 @@ requires = [
 extras = {
     'rl': ['rlgym-rocket-league[all] =={}'.format(rl_version)],
     'rl-sim': ['rlgym-rocket-league[sim] =={}'.format(rl_version)],
-    'rl-fullsim': ['rlgym-rocket-league[rlviser] =={}'.format(rl_version)],
+    'rl-rlviser': ['rlgym-rocket-league[rlviser] =={}'.format(rl_version)],
     'rl-game': ['rlgym-rocket-league[game] =={}'.format(rl_version)],
 }
 


### PR DESCRIPTION
I believe the V2 is misisng an option to be able to install as `rlgym[rl-sim]` while still including `rlviser-py`. rlviser-py is already ready in [`extras['rlviser'].extend(extras['sim'])`](https://github.com/lucas-emery/rocket-league-gym/blob/b963686d90d5f7be6f3b0653dcac16ac82dc3889/setup_rocket_league.py#L40C1-L40C40) but not used since there is no option for installing rlgym[rlviser].

My suggestion is a `rlgym[rl-fullsim]` which will run `rlgym[rlviser]` thus installing both rocketsim and rlviser-py.