### PR TITLE
fix non-padded get_obs_space call

### DIFF
--- a/rlgym/rocket_league/obs_builders/default_obs.py
+++ b/rlgym/rocket_league/obs_builders/default_obs.py
@@ -31,15 +31,18 @@ class DefaultObs(ObsBuilder[AgentID, np.ndarray, GameState, Tuple[str, int]]):
         self.PAD_TIMER_COEF = pad_timer_coef
         self.BOOST_COEF = boost_coef
         self.zero_padding = zero_padding
+        self.n_agents = None
 
     def get_obs_space(self, agent: AgentID) -> Tuple[str, int]:
         if self.zero_padding is not None:
             return 'real', 52 + 20 * self.zero_padding * 2
+        elif self.n_agents is not None:
+            return 'real', 52 + 20 * self.n_agents
         else:
-            return 'real', -1  # Without zero padding this depends on the initial state, but we don't want to crash for now
+            return 'real', -1 # Without zero padding this depends on the initial state, but we don't want to crash for now
 
     def reset(self, agents: List[AgentID], initial_state: GameState, shared_info: Dict[str, Any]) -> None:
-        pass
+        self.n_agents = len(initial_state.cars)
 
     def build_obs(self, agents: List[AgentID], state: GameState, shared_info: Dict[str, Any]) -> Dict[AgentID, np.ndarray]:
         obs = {}

--- a/rlgym/rocket_league/obs_builders/default_obs.py
+++ b/rlgym/rocket_league/obs_builders/default_obs.py
@@ -31,20 +31,21 @@ class DefaultObs(ObsBuilder[AgentID, np.ndarray, GameState, Tuple[str, int]]):
         self.PAD_TIMER_COEF = pad_timer_coef
         self.BOOST_COEF = boost_coef
         self.zero_padding = zero_padding
-        self.n_agents = None
+        self._state = None
 
     def get_obs_space(self, agent: AgentID) -> Tuple[str, int]:
         if self.zero_padding is not None:
             return 'real', 52 + 20 * self.zero_padding * 2
-        elif self.n_agents is not None:
-            return 'real', 52 + 20 * self.n_agents
+        elif self._state is not None:
+            return 'real', 52 + 20 * len(self._state.cars)
         else:
-            return 'real', -1 # Without zero padding this depends on the initial state, but we don't want to crash for now
+            return 'real', -1 # Without zero padding this depends on the current state, but we don't have one yet
 
     def reset(self, agents: List[AgentID], initial_state: GameState, shared_info: Dict[str, Any]) -> None:
-        self.n_agents = len(initial_state.cars)
+        self._state = initial_state
 
     def build_obs(self, agents: List[AgentID], state: GameState, shared_info: Dict[str, Any]) -> Dict[AgentID, np.ndarray]:
+        self._state = state
         obs = {}
         for agent in agents:
             obs[agent] = self._build_obs(agent, state, shared_info)

--- a/rlgym/rocket_league/state_mutators/fixed_team_size_mutator.py
+++ b/rlgym/rocket_league/state_mutators/fixed_team_size_mutator.py
@@ -32,11 +32,12 @@ class FixedTeamSizeMutator(StateMutator[GameState]):
     def _new_car(self) -> Car:
         car = Car()
         car.hitbox_type = OCTANE
+        car.ball_touches = 0
 
         car.physics = PhysicsObject()
 
         car.demo_respawn_timer = 0.
-        car.on_ground = True
+        car.wheels_with_contact = (True, True, True, True)
         car.supersonic_time = 0.
         car.boost_amount = 0.
         car.boost_active_time = 0.

--- a/rlgym/rocket_league/state_mutators/fixed_team_size_mutator.py
+++ b/rlgym/rocket_league/state_mutators/fixed_team_size_mutator.py
@@ -37,7 +37,7 @@ class FixedTeamSizeMutator(StateMutator[GameState]):
         car.physics = PhysicsObject()
 
         car.demo_respawn_timer = 0.
-        car.wheels_with_contact = (True, True, True, True)
+        car.on_ground = True
         car.supersonic_time = 0.
         car.boost_amount = 0.
         car.boost_active_time = 0.


### PR DESCRIPTION
Store the number of agents in the initial state on reset, and use this to calculate the obs space size if reset has already been called and we are not using zero padding