### PR TITLE
update math.py keep dtype when converting orientation forms

### DIFF
--- a/rlgym/rocket_league/math.py
+++ b/rlgym/rocket_league/math.py
@@ -110,7 +110,7 @@ def quat_to_euler(quat: np.ndarray) -> np.ndarray:
         pitch = np.arcsin(sinp)
     yaw = np.arctan2(siny_cosp, cosy_cosp)
 
-    return np.array([-pitch, yaw, -roll])
+    return np.array([-pitch, yaw, -roll], dtype=quat.dtype)
 
 
 # From RLUtilities
@@ -127,7 +127,7 @@ def quat_to_rot_mtx(quat: np.ndarray) -> np.ndarray:
     y = -quat[2]
     z = -quat[3]
 
-    theta = np.zeros((3, 3))
+    theta = np.zeros((3, 3), dtype=quat.dtype)
 
     norm = np.dot(quat, quat)
     if norm != 0:
@@ -160,7 +160,7 @@ def rotation_to_quaternion(m: np.ndarray) -> np.ndarray:
     :return: A numpy array of size 4 representing the quaternion.
     """
     trace = np.trace(m)
-    q = np.zeros(4)
+    q = np.zeros(4, dtype=m.dtype)
 
     if trace > 0:
         s = (trace + 1) ** 0.5
@@ -208,7 +208,7 @@ def euler_to_rotation(pyr: np.ndarray) -> np.ndarray:
     cp, cy, cr = np.cos(pyr)
     sp, sy, sr = np.sin(pyr)
 
-    theta = np.zeros((3, 3))
+    theta = np.zeros((3, 3), dtype=pyr.dtype)
 
     # front
     theta[0, 0] = cp * cy


### PR DESCRIPTION
math.py's functions `quat_to_euler`, `quat_to_rot_mtx`, `rotation_to_quaternion`, `euler_to_rotation` all return numpy arrays with float64 no matter what the dtype of the input was. This PR updates that so that the returned numpy arrays have the same dtype as the input.